### PR TITLE
Worker: library for managing child processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+    "worker",
+]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 async-stream = "0.3"
 bytes = "1.0"
 futures = "0.3"
+log = "0.4"
 nix = "0.20"
 tokio = { version = "1.3", features = ["full"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -12,4 +12,5 @@ bytes = "1.0"
 futures = "0.3"
 log = "0.4"
 nix = "0.20"
+thiserror = "1.0"
 tokio = { version = "1.3", features = ["full"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-stream = "0.3"
 bytes = "1.0"
-tokio = { version = "1.3", features = ["process", "rt", "sync"] }
+futures = "0.3"
+tokio = { version = "1.3", features = ["io-util", "macros", "process", "rt", "sync"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "worker"
+version = "0.1.0"
+authors = ["Justinas Stankevicius <justinas@justinas.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = "1.0"
+tokio = { version = "1.3", features = ["process", "rt", "sync"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -10,4 +10,5 @@ edition = "2018"
 async-stream = "0.3"
 bytes = "1.0"
 futures = "0.3"
-tokio = { version = "1.3", features = ["io-util", "macros", "process", "rt", "sync"] }
+nix = "0.20"
+tokio = { version = "1.3", features = ["full"] }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,0 +1,65 @@
+use std::{io::Error as IoError, process::ExitStatus, sync::Arc};
+
+use bytes::Bytes;
+use tokio::{
+    process::Command,
+    sync::{Notify, RwLock},
+};
+
+#[derive(Default)]
+struct ProcessInner {
+    exit_status: RwLock<Option<ExitStatus>>,
+    logs: Vec<Bytes>,
+    progress: Notify,
+}
+
+impl ProcessInner {
+    async fn finish(&self, exit_status: ExitStatus) {
+        *self.exit_status.write().await = Some(exit_status);
+    }
+}
+
+struct Process(Arc<ProcessInner>);
+
+impl Process {
+    pub fn spawn<'a>(argv0: &str, argv: impl Iterator<Item = &'a str>) -> Result<Self, IoError> {
+        let inner = Arc::new(ProcessInner::default());
+        let inner_clone = inner.clone();
+        let mut cmd = Command::new(argv0).args(argv).spawn()?;
+        tokio::spawn(async move {
+            // TODO: read stdin/stdout
+            match cmd.wait().await {
+                Ok(s) => inner.finish(s).await,
+                Err(_) => unimplemented!("when does this happen?"), // TODO
+            }
+        });
+        Ok(Process(inner_clone))
+    }
+
+    pub async fn status(&self) -> Option<ExitStatus> {
+        *self.0.exit_status.read().await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Process;
+    use std::time::Duration;
+
+    fn empty_args() -> impl Iterator<Item = &'static str> {
+        (&mut []).iter().cloned()
+    }
+
+    #[should_panic]
+    #[tokio::test]
+    async fn test_process_spawn_not_found() {
+        Process::spawn("this_command_does_not_exist", empty_args()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_process_spawn() {
+        let p = Process::spawn("true", empty_args()).unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await; // TODO: proper wait
+        assert_eq!(p.status().await.unwrap().code(), Some(0));
+    }
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 use bytes::Bytes;
 use futures::{future::FusedFuture, FutureExt, Stream};
+use log::error;
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, BufReader},
     process::{Child, Command},
@@ -63,18 +64,15 @@ async fn process_task(
             copy_log(stderr, inner.clone())
         ) => {
             if let Err(e) = copied.0 {
-                // TODO: use `log` crate
-                eprintln!("{:?}", e);
+                error!("{:?}", e);
             }
             if let Err(e) = copied.1 {
-                // TODO: use `log` crate
-                eprintln!("{:?}", e);
+                error!("{:?}", e);
             }
         },
         _ = &mut stop_receiver => {
             if let Err(e) = stop_child(&mut child).await {
-                // TODO: use `log` crate
-                eprintln!("{:?}", e);
+                error!("{:?}", e);
             }
         },
     );
@@ -86,8 +84,7 @@ async fn process_task(
         tokio::select! {
             _ = &mut stop_receiver, if !stop_receiver.is_terminated() => {
                 if let Err(e) = stop_child(&mut child).await {
-                    // TODO: use `log` crate
-                    eprintln!("{:?}", e);
+                    error!("{:?}", e);
                 }
             },
             res = child.wait() => {

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -67,7 +67,7 @@ async fn process_task(
                         inner.progress.notify_waiters();
                         return;
                     }
-                    Err(_) => unimplemented!("when does this happen?"), // TODO
+                    Err(e) => panic!("Unexpected error from wait(): {:?}", e),
                 }
             }
         }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -204,7 +204,7 @@ mod test {
             echo world
             sleep 2
         ";
-        let p = Process::spawn("/usr/bin/env", ["bash", "-c", script].iter().cloned()).unwrap();
+        let p = Process::spawn("bash", ["-c", script].iter().cloned()).unwrap();
         let logs = p.logs();
         pin_mut!(logs);
         assert_eq!(logs.next().await.as_deref(), Some(&b"hello"[..]));
@@ -220,7 +220,7 @@ mod test {
                 sleep 1
             done;
         ";
-        let p = Process::spawn("/usr/bin/env", ["bash", "-c", script].iter().cloned()).unwrap();
+        let p = Process::spawn("bash", ["-c", script].iter().cloned()).unwrap();
         assert_eq!(
             p.stop().await.unwrap().signal().unwrap(),
             nix::sys::signal::Signal::SIGTERM as i32
@@ -242,7 +242,7 @@ mod test {
             done;
         "#;
 
-        let p = Process::spawn("/usr/bin/env", ["bash", "-c", script].iter().cloned()).unwrap();
+        let p = Process::spawn("bash", ["-c", script].iter().cloned()).unwrap();
 
         // Wait until bash executes at least "trap"
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -26,7 +26,6 @@ async fn copy_log<R: AsyncBufRead + Unpin>(
         process.logs.write().await.push(Bytes::from(line));
         process.progress.notify_waiters();
     }
-    process.progress.notify_waiters();
     Ok(())
 }
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::Error as IoError,
+    io,
     process::{ExitStatus, Stdio},
     sync::Arc,
 };
@@ -104,7 +104,7 @@ pub struct Process(Arc<ProcessInner>);
 
 impl Process {
     /// Spawn a new process.
-    pub fn spawn<'a>(argv0: &str, argv: impl Iterator<Item = &'a str>) -> Result<Self, IoError> {
+    pub fn spawn<'a>(argv0: &str, argv: impl Iterator<Item = &'a str>) -> Result<Self, io::Error> {
         let (stop_tx, stop_rx) = oneshot::channel();
         let inner = Arc::new(ProcessInner::new(stop_tx));
         let inner_clone = inner.clone();

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,16 +1,36 @@
-use std::{io::Error as IoError, process::ExitStatus, sync::Arc};
+use std::{
+    io::Error as IoError,
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+};
 
 use bytes::Bytes;
+use futures::Stream;
 use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, BufReader},
     process::Command,
     sync::{Notify, RwLock},
 };
 
+async fn copy_log<R: AsyncBufRead + Unpin>(
+    reader: R,
+    process: Arc<ProcessInner>,
+) -> Result<(), IoError> {
+    let mut lines = reader.lines();
+    // TODO: re-locks each line, not too efficient
+    while let Some(line) = lines.next_line().await? {
+        process.logs.write().await.push(Bytes::from(line));
+        process.progress.notify_waiters();
+    }
+    process.progress.notify_waiters();
+    Ok(())
+}
+
 #[derive(Default)]
 struct ProcessInner {
     exit_status: RwLock<Option<ExitStatus>>,
-    logs: Vec<Bytes>,
-    progress: Notify,
+    logs: RwLock<Vec<Bytes>>,
+    progress: Arc<Notify>,
 }
 
 impl ProcessInner {
@@ -19,21 +39,77 @@ impl ProcessInner {
     }
 }
 
-struct Process(Arc<ProcessInner>);
+pub struct Process(Arc<ProcessInner>);
 
 impl Process {
     pub fn spawn<'a>(argv0: &str, argv: impl Iterator<Item = &'a str>) -> Result<Self, IoError> {
         let inner = Arc::new(ProcessInner::default());
         let inner_clone = inner.clone();
-        let mut cmd = Command::new(argv0).args(argv).spawn()?;
+        let mut child = Command::new(argv0)
+            .args(argv)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
         tokio::spawn(async move {
-            // TODO: read stdin/stdout
-            match cmd.wait().await {
-                Ok(s) => inner.finish(s).await,
+            let stdout = BufReader::new(child.stdout.take().expect("should always be available"));
+            let stderr = BufReader::new(child.stderr.take().expect("should always be available"));
+
+            let copied = tokio::join!(
+                copy_log(stdout, inner.clone()),
+                copy_log(stderr, inner.clone())
+            );
+            if let Err(e) = copied.0 {
+                // TODO: use `log` crate
+                eprintln!("{:?}", e);
+            }
+            if let Err(e) = copied.1 {
+                // TODO: use `log` crate
+                eprintln!("{:?}", e);
+            }
+            match child.wait().await {
+                Ok(s) => {
+                    inner.finish(s).await;
+                    inner.progress.notify_waiters();
+                }
                 Err(_) => unimplemented!("when does this happen?"), // TODO
             }
         });
+
         Ok(Process(inner_clone))
+    }
+
+    pub fn logs(&self) -> impl Stream<Item = Bytes> {
+        let inner = self.0.clone();
+        let notify = inner.progress.clone();
+        let mut pos = 0;
+        Box::pin(async_stream::stream! {
+            loop {
+                let notified = notify.notified();
+                let line = {
+                    // TODO: batch
+                    let logs = inner.logs.read().await;
+                    if pos < logs.len() {
+                        let line = logs[pos].clone();
+                        pos += 1;
+                        Some(line)
+                    } else {
+                        None
+                    }
+                };
+                if let Some(l) = line {
+                    yield l;
+                }
+                let process_finished = inner.exit_status.read().await.is_some();
+                let has_read_all = pos == inner.logs.read().await.len();
+                if process_finished && has_read_all {
+                    return;
+                }
+                if has_read_all {
+                    notified.await;
+                }
+            }
+        })
     }
 
     pub async fn status(&self) -> Option<ExitStatus> {
@@ -44,7 +120,7 @@ impl Process {
 #[cfg(test)]
 mod test {
     use super::Process;
-    use std::time::Duration;
+    use futures::StreamExt;
 
     fn empty_args() -> impl Iterator<Item = &'static str> {
         (&mut []).iter().cloned()
@@ -58,8 +134,27 @@ mod test {
 
     #[tokio::test]
     async fn test_process_spawn() {
-        let p = Process::spawn("true", empty_args()).unwrap();
-        tokio::time::sleep(Duration::from_secs(1)).await; // TODO: proper wait
+        let p = Process::spawn("echo", ["foo"].iter().cloned()).unwrap();
+        let mut logs = p.logs();
+        assert_eq!(logs.next().await.as_deref(), Some(&b"foo"[..]));
+        assert_eq!(logs.next().await, None);
         assert_eq!(p.status().await.unwrap().code(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_process_log_stream() {
+        let script = "
+            echo hello
+            sleep 1
+            echo beautiful
+            echo world
+            sleep 2
+        ";
+        let p = Process::spawn("/usr/bin/env", ["bash", "-c", &script].iter().cloned()).unwrap();
+        let mut logs = p.logs();
+        assert_eq!(logs.next().await.as_deref(), Some(&b"hello"[..]));
+        assert_eq!(logs.next().await.as_deref(), Some(&b"beautiful"[..]));
+        assert_eq!(logs.next().await.as_deref(), Some(&b"world"[..]));
+        assert_eq!(logs.next().await, None);
     }
 }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -21,7 +21,7 @@ async fn process_task(
     inner: Arc<ProcessInner>,
     stop_receiver: oneshot::Receiver<()>,
 ) {
-    // A child process might close botth stdout and stderr,
+    // A child process might close both stdout and stderr,
     // but remain alive. In that case, we must still try to wait
     // for the stop message.
     // Fuse the future to be able to .await twice safely (when !is_terminated()).

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -194,7 +194,10 @@ impl Process {
             loop {
                 let notified = notify.notified();
                 let line = {
-                    // TODO: batch
+                    // TODO: read multiple lines here for efficiency.
+                    // We use `bytes::Bytes` and it is internally ref-counted,
+                    // so perhaps clone `Bytes` objects to a stack buffer,
+                    // unlock quickly, then yield each object outside of the lock.
                     let logs = inner.logs.read().await;
                     if pos < logs.len() {
                         let line = logs[pos].clone();

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -31,7 +31,7 @@ async fn process_task(
     let stderr = BufReader::new(child.stderr.take().expect("should always be available"));
 
     // Phase 1: copy logs from stdout/stderr, on stop message: signal the child.
-    tokio::select!(
+    tokio::select! {
         copied = futures::future::join(
             logs::copy(stdout, inner.clone()),
             logs::copy(stderr, inner.clone())
@@ -48,7 +48,7 @@ async fn process_task(
                 error!("{:?}", e);
             }
         },
-    );
+    };
 
     // Phase 2: stdout/stderr have been closed,
     // wait for a stop message to arrive (if not arrived yet),

--- a/worker/src/logs.rs
+++ b/worker/src/logs.rs
@@ -1,0 +1,56 @@
+use std::io::Error as IoError;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::Stream;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+
+use super::ProcessInner;
+
+pub(crate) async fn copy<R: AsyncBufRead + Unpin>(
+    reader: R,
+    process: Arc<ProcessInner>,
+) -> Result<(), IoError> {
+    let mut lines = reader.lines();
+    // TODO: re-locks each line, not too efficient
+    while let Some(line) = lines.next_line().await? {
+        process.logs.write().await.push(Bytes::from(line));
+        process.progress.notify_waiters();
+    }
+    Ok(())
+}
+
+pub(crate) fn stream(process: Arc<ProcessInner>) -> impl Stream<Item = Bytes> {
+    let notify = process.progress.clone();
+    let mut pos = 0;
+    async_stream::stream! {
+        loop {
+            let notified = notify.notified();
+            let line = {
+                // TODO: read multiple lines here for efficiency.
+                // We use `bytes::Bytes` and it is internally ref-counted,
+                // so perhaps clone `Bytes` objects to a stack buffer,
+                // unlock quickly, then yield each object outside of the lock.
+                let logs = process.logs.read().await;
+                if pos < logs.len() {
+                    let line = logs[pos].clone();
+                    pos += 1;
+                    Some(line)
+                } else {
+                    None
+                }
+            };
+            if let Some(l) = line {
+                yield l;
+            }
+            let process_finished = process.exit_status.read().await.is_some();
+            let has_read_all = pos == process.logs.read().await.len();
+            if process_finished && has_read_all {
+                return;
+            }
+            if has_read_all {
+                notified.await;
+            }
+        }
+    }
+}

--- a/worker/src/ops.rs
+++ b/worker/src/ops.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+use nix::{
+    sys::signal::{self, kill},
+    unistd::Pid,
+};
+use tokio::{process::Child, time::timeout};
+
+const SIGTERM_TIMEOUT: Duration = Duration::from_secs(5);
+
+// TODO: a better error type
+pub async fn stop_child(child: &mut Child) -> Result<(), Box<dyn std::error::Error>> {
+    let pid = match child.id() {
+        Some(id) => id,
+        None => return Ok(()),
+    } as i32; // TODO: dubious cast? pid_t is i32 in `nix`, but u32 in `std`.
+    kill(Pid::from_raw(pid), signal::SIGTERM)?;
+    if timeout(SIGTERM_TIMEOUT, child.wait()).await.is_ok() {
+        return Ok(());
+    }
+    Ok(child.kill().await?)
+}

--- a/worker/src/ops.rs
+++ b/worker/src/ops.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{io, time::Duration};
 
 use nix::{
     sys::signal::{self, kill},
@@ -11,7 +11,7 @@ const SIGTERM_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug, thiserror::Error)]
 pub enum StopError {
     #[error("I/O error while stopping the process: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] io::Error),
     #[error("Syscall error while stopping the process: {0}")]
     Nix(#[from] nix::Error),
 }


### PR DESCRIPTION
Implements all the process management that will be required by `paasd`: start, stop, stream logs and check for exit status.